### PR TITLE
Improved README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 <h1>JellySkin</h1><h3>Use 67% or 70% zoom in web browser for better experience</h3>
-<h4>Note: To take full experience of this CSS on FireFox scroll down to the bottom of the page.</h4>
+<h4>Note: To take full experience of this CSS on FireFox scroll down below to find the necessary settings.</h4>
 </div>
 <br>
 <h3>How to use</h3>

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ becomes (with only adding the default style):
 add_header Content-Security-Policy "default-src https: data: blob: http://image.tmdb.org; style-src 'self' 'unsafe-inline' https://prayag17.github.io/JellySkin/default.css; script-src 'self' 'unsafe-inline' https://www.gstatic.com/cv/js/sender/v1/cast_sender.js https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
 ```
 
-If you don't do this the theme will simply not load (reverts back to default theme) and the browser console will spit out an error. Even if you paste in all the CSS, the font will still not load since it is loaded from an external source.
+If you don't do this the theme will simply not load (reverts back to default theme) and the browser console will spit out an error. Even if you paste in all the CSS, the font will still not load since it is loaded from a disallowed external source.
   </div>
   
 <div class="conribute" align="center" style="text-align: center;">

--- a/README.md
+++ b/README.md
@@ -92,18 +92,6 @@ Add the follwing line to custom CSS with the default css file-
 <br>
 <br>
 
-<div class="conribute" align="center" style="text-align: center;">
-<h2> Wanna Contribute? </h2>
-<ul>
-<li>Fork this Repo</li>
-<li>Add your features</li>
-<li>Create a Pull Request</li>
-<li>Wait for it to be merged.</li>
-</ul>
-</div>
-<br>
-<br>
-
 <div class="firefox">
 <h4 align="center">Enabling backdrop-filter in firefox</h4>
 
@@ -124,6 +112,7 @@ preference (needs to be set to
 
 
 <div class="nginx-reverseproxy">
+<h3>Using Nginx Reverse Proxy</h3>
 When using the Nginx Reverse proxy config from the [Jellyfin docs](https://jellyfin.org/docs/general/networking/nginx.html) the theme will probably not work by default. (If you are using the subpath config, you can ignore all this.)
 
 This config includes an CSP (Content Security Policy) with headers that don't allow for loading in external content that are not defined there.
@@ -142,3 +131,14 @@ add_header Content-Security-Policy "default-src https: data: blob: http://image.
 
 If you don't do this the theme will simply not load (reverts back to default theme) and the browser console will spit out an error. Even if you paste in all the CSS, the font will still not load since it is loaded from an external source.
   
+<div class="conribute" align="center" style="text-align: center;">
+<h2> Wanna Contribute? </h2>
+<ul>
+<li>Fork this Repo</li>
+<li>Add your features</li>
+<li>Create a Pull Request</li>
+<li>Wait for it to be merged.</li>
+</ul>
+</div>
+<br>
+<br>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <div align="center">
 <h1>JellySkin</h1><h3>Use 67% or 70% zoom in web browser for better experience</h3>
-<h4>Note:To take full experience of this CSS on fire fox click <a href="#firefox">here</a></strong>.</h4>
+<h4>Note:To take full experience of this CSS on FireFox click <a href="#firefox">here</a></strong>.</h4>
 </div>
 <br>
-This is JellySkin:
-To use just copy this :
+<h3>How to use</h3>
+To use the JellySkin theme copy the line below into "Dashboard -> General -> Custom CSS" and click save, it will apply immediately server-wide to all users on top of any theme they may be using. To remove the theme, clear the "Custom CSS" field and then click save. <b>NOTE: Theme may not work when using reverse proxy</b> click <a href="#nginx-reverseproxy">here</a></strong> to learn how to fix this.
 
 ```css
 @import url("https://prayag17.github.io/JellySkin/default.css");
@@ -17,14 +17,14 @@ To use Logos like the images given below use:
 <br>
 
 ```css
-@import url("https://prayag17.github.io/JellySkin/addons/imp-per.css)
+@import url("https://prayag17.github.io/JellySkin/addons/imp-per.css");
 ```
 
 <br>
 <h3>If you want to display your posters to be compact use the following line with default css</h3>
 
 ```css
-@import url("https://prayag17.github.io/JellySkin/addons/compact-poster.css")
+@import url("https://prayag17.github.io/JellySkin/addons/compact-poster.css");
 ```
 
 To use different gradient for your buttons I have added few different gradients you can choose or you can create your own (check the steps given bellow), the default gradient used is jellyfin's default logo gradient,using this alone will only skin the button colors and I know the names for this are very funny:
@@ -34,7 +34,6 @@ To use different gradient for your buttons I have added few different gradients 
 @import url("https://prayag17.github.io/JellySkin/addons/Gradients/mauveGradient.css");
 @import url("https://prayag17.github.io/JellySkin/addons/Gradients/nightSkyGradient.css");
 ```
-and past it in custom css text box and click save. To open Custom CSS settings go to Dashboard>General>Custom CSS.
 <br>
 Using custom own Gradient or color
 Create your gradient or solid color and past it in ```--accent``` and gradient in opposite angle in ```--accent-selected``` :
@@ -122,3 +121,24 @@ preference (needs to be set to
 </code>
 
 </div>
+
+
+<div class="nginx-reverseproxy">
+When using the Nginx Reverse proxy config from the [Jellyfin docs](https://jellyfin.org/docs/general/networking/nginx.html) the theme will probably not work by default. (If you are using the subpath config, you can ignore all this.)
+
+This config includes an CSP (Content Security Policy) with headers that don't allow for loading in external content that are not defined there.
+
+In the nginx config you should add the URLs of all the CSS files you've imported through the "Custom CSS" box.
+this:
+
+```
+add_header Content-Security-Policy "default-src https: data: blob: http://image.tmdb.org; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com/cv/js/sender/v1/cast_sender.js https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
+```
+becomes (with only adding the default style):
+
+```
+add_header Content-Security-Policy "default-src https: data: blob: http://image.tmdb.org; style-src 'self' 'unsafe-inline' https://prayag17.github.io/JellySkin/default.css; script-src 'self' 'unsafe-inline' https://www.gstatic.com/cv/js/sender/v1/cast_sender.js https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
+```
+
+If you don't do this the theme will simply not load (reverts back to default theme) and the browser console will spit out an error. Even if you paste in all the CSS, the font will still not load since it is loaded from an external source.
+  

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ preference (needs to be set to
 
 <div class="nginx-reverseproxy">
 <h3>Using Nginx Reverse Proxy</h3>
-When using the Nginx Reverse proxy config from the [Jellyfin docs](https://jellyfin.org/docs/general/networking/nginx.html) the theme will probably not work by default. (If you are using the subpath config, you can ignore all this.)
+  When using the Nginx Reverse proxy config from the <a href="https://jellyfin.org/docs/general/networking/nginx.html">Jellyfin docs</a> the theme will probably not work by default. (If you are using the subpath config, you can ignore all this.)
 
 This config includes an CSP (Content Security Policy) with headers that don't allow for loading in external content that are not defined there.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <div align="center">
 <h1>JellySkin</h1><h3>Use 67% or 70% zoom in web browser for better experience</h3>
-<h4>Note:To take full experience of this CSS on FireFox click <a href="#firefox">here</a></strong>.</h4>
+<h4>Note: To take full experience of this CSS on FireFox scroll down to the bottom of the page.</h4>
 </div>
 <br>
 <h3>How to use</h3>
-To use the JellySkin theme copy the line below into "Dashboard -> General -> Custom CSS" and click save, it will apply immediately server-wide to all users on top of any theme they may be using. To remove the theme, clear the "Custom CSS" field and then click save. <b>NOTE: Theme may not work when using reverse proxy</b> click <a href="#nginx-reverseproxy">here</a></strong> to learn how to fix this.
+To use the JellySkin theme copy the line below into "Dashboard -> General -> Custom CSS" and click save, it will apply immediately server-wide to all users on top of any theme they may be using. To remove the theme, clear the "Custom CSS" field and then click save. <b>NOTE: Theme may not work when using Nginx Reverse Proxy. Scroll down below to learn how to fix this.
 
 ```css
 @import url("https://prayag17.github.io/JellySkin/default.css");
@@ -93,7 +93,7 @@ Add the follwing line to custom CSS with the default css file-
 <br>
 
 <div class="firefox">
-<h4 align="center">Enabling backdrop-filter in firefox</h4>
+<h3>Enabling backdrop-filter in FireFox</h3>
 
 <code style="display: block !important;">
 Deaktiviert From version 70: this feature is behind the
@@ -130,6 +130,7 @@ add_header Content-Security-Policy "default-src https: data: blob: http://image.
 ```
 
 If you don't do this the theme will simply not load (reverts back to default theme) and the browser console will spit out an error. Even if you paste in all the CSS, the font will still not load since it is loaded from an external source.
+  </div>
   
 <div class="conribute" align="center" style="text-align: center;">
 <h2> Wanna Contribute? </h2>


### PR DESCRIPTION
I fixed/improved numerous things in README.md:
- Restructured and rewrote some parts so that it all makes sense (ie. starting with a how to use instead of it being buried somewhere in the middle.)
- More consistant styling
- Fixed typo's in some CSS links that made it impossible to import
- Changed some redirects (ie. the Firefox one originally on line 3 that didn't do anything.)
- Added a section on how to use JellySkin with a Nginx Reverse Proxy

If you allow it I would like to rewrite README.md entirely to use Githubs syntax instead of HTML