### PR TITLE
Fix top margin behaviour for no logo pages

### DIFF
--- a/addons/Logo.css
+++ b/addons/Logo.css
@@ -7,14 +7,7 @@
     flex-shrink: 0;
     background-position: 0 50%;
     margin-top: 8vh;
-}
-
-.layout-desktop .detailRibbon {
-    margin-top: 0;
-}
-
-.layout-mobile .detailRibbon {
-    margin-top: 0 !important;
+    margin-bottom: -10em;
 }
 
 .layout-mobile .detailLogo {


### PR DESCRIPTION
This uses a negative margin .detaiLogo instead of zeroing the margin on .detalRibbon, to align the logo with the ribbon.

This leaves .detailRibbon without changes, meaning it can keep it's own code, so it doesn't go weird for items with no logo.