### PR TITLE
fix: home page card button padding

### DIFF
--- a/src/components/_cards.scss
+++ b/src/components/_cards.scss
@@ -177,7 +177,7 @@
 .listItemIndicators {
 	@include indicator();
 }
-[data-isfolder="true"][data-type="CollectionFolder"]:not([data-type="Series"])
+[data-isfolder="true"]:is([data-type=CollectionFolder],[data-type=UserView]):not([data-type="Series"])
 	.cardText {
 	padding: 0.75em !important;
 }


### PR DESCRIPTION
This PR will fix an issue where playlists have a smaller height than the other cards on home page.

Example:
![2024-02-20_19-06-47-425_brave](https://github.com/prayag17/JellySkin/assets/26493496/ea7210f2-b95b-445f-914d-6d0a29d180f9)
