### PR TITLE
Fix: connected cast button icon

### DIFF
--- a/src/components/_header.scss
+++ b/src/components/_header.scss
@@ -47,3 +47,8 @@ div[data-role="page"].page {
 	backdrop-filter: blur($filter-blur-default);
 	box-shadow: 0 0 15px black;
 }
+
+// Cast management button fix
+.material-icons.cast_connected:before {
+    content: "\f1de" !important;
+}

--- a/src/components/_header.scss
+++ b/src/components/_header.scss
@@ -50,5 +50,5 @@ div[data-role="page"].page {
 
 // Cast management button fix
 .material-icons.cast_connected:before {
-    content: "\f1de" !important;
+    content: "\f1de";
 }


### PR DESCRIPTION
fix: #127 

Given that https://github.com/prayag17/Jellyfin-Icons is archived the only solution to fix this issue is to apply the change directly here.
Jellyfin-icons is imported as a dependency here: https://github.com/prayag17/JellySkin/blob/master/src/abstract/_fonts.scss#L4