### PR TITLE
style: add blur to video theme backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@
         --accent2-dark: YOUR ACCENT COLOR 2(DARKER SHADE);
       }
       ```
+- ## Add blur to video theme backgrounds
+
+    Adds the blur effect present on static backgrounds to video theme backgrounds as well.
+    *Caution*: This is a performance intensive filter and may cause considerable slowdowns on some devices.
+    If you are adding this to the serverwide Custom CSS, users can remove the effect using the *Remove Backdrop Filter* addon above.
+
+    ```css
+    @import url("https://cdn.jsdelivr.net/npm/jellyskin@latest/dist/addons/videoThemeBlur.css");
+    ```
 
 # 💻 Screenshots
 

--- a/src/addons/videoThemeBlur.scss
+++ b/src/addons/videoThemeBlur.scss
@@ -1,0 +1,7 @@
+/** @format */
+
+@use "../abstract/variables" as *;
+.videoPlayerContainer ~ #reactRoot .backgroundContainer.withBackdrop {
+	backdrop-filter: blur($filter-blur-default);
+	opacity: 1;
+}


### PR DESCRIPTION
I like blur, and I also like using video backgrounds, and we can also combine the two.

Setting a blur on the `videoPlayerContainer` doesn't work because it would affect actual video playback too. So this is the next best approach. We could *always* apply a blur to the `reactRoot` but I wasn't sure what else that would affect, so I went the safe route with a sibling-selector.

Since it's a `backdrop-filter` it doesn't require additional rules for the `removeBackdropFilter.css`.