### PR TITLE
fix: Live TV Guide doesn't scroll down

### DIFF
--- a/src/components/_cards.scss
+++ b/src/components/_cards.scss
@@ -7,6 +7,9 @@
 	overflow: visible !important;
 	margin-top: 0.5em;
 }
+.liveTvContainer #guideTab .emby-scroller {
+    overflow: auto !important;
+}
 
 .layout-mobile .emby-scroller{
 	overflow-x: scroll !important;

--- a/src/components/_cards.scss
+++ b/src/components/_cards.scss
@@ -8,7 +8,7 @@
 	margin-top: 0.5em;
 }
 .liveTvContainer #guideTab .emby-scroller {
-    overflow: auto !important;
+	overflow: auto !important;
 }
 
 .layout-mobile .emby-scroller{


### PR DESCRIPTION
## Problem  
When using the JellySkin theme, the Live TV guide does not scroll down as expected. This issue has been reported multiple times and was previously identified as a server-side bug in Jellyfin. It was resolved in the following issues:  
- [Jellyfin GitHub Issue #5705](https://github.com/jellyfin/jellyfin-web/issues/5705)  
- [Forum Discussion: Live TV Guide Scrolling](https://forum.jellyfin.org/t-livetv-guide-scrolling)  

However, when using the JellySkin theme, the issue reappears.  

## Cause  
As noted in the Jellyfin issue, this problem is caused by the emby scroller and its `overflow` CSS property.  

## Solution  
To resolve this issue, I have added a CSS selector to reset the `overflow` property to `auto` when the `liveTvContainer` class is active and the user is on the `guideTab`.