### PR TITLE
Added Configuration for Selective Inclusion of Parts of Theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /dev
 /node_modules
 /dist
+
+*.css
+
+*.map

--- a/src/abstract/_config.scss
+++ b/src/abstract/_config.scss
@@ -1,0 +1,42 @@
+/** @format */
+
+/*
+  Include Configuration
+    Exclude certain core parts of the theme by
+    setting the value to false.
+*/
+// Abstract
+//   Font Stlye Changes
+$abstract-fonts: true;
+
+// Components
+//   Button Style Changes
+$component-button: true;
+//   Cards Style Changes
+$component-cards: true;
+//   Header Style Changes
+$component-header: true;
+//   Input Element Style Changes
+$component-input: true;
+//   Links Style Changes
+$component-links: true;
+//   Manue Style Changes
+$component-menu: true;
+//   Scrollbar Style Changes
+$component-scrollbars: true;
+//   Side Menu Style Changes
+$component-sidemenu: true;
+//   Slider Bubble Style Changes
+$component-sliderBubble: true;
+
+// Pages
+//   Dashboard Page Style Changes
+$pages-dashboard: true;
+//   Main/Library Page Style Changes
+$pages-indexPage: true;
+//   Login Page Style Changes
+$pages-loginPage: true;
+//   Player Page Style Changes
+$pages-player: true;
+//   Show/Movies Page Style Changes
+$pages-titlePage: true;

--- a/src/abstract/_config.scss
+++ b/src/abstract/_config.scss
@@ -14,6 +14,8 @@ $abstract-fonts: true;
 $component-button: true;
 //   Cards Style Changes
 $component-cards: true;
+//   Solid color completed indicator
+$component-cards-indicator-solid-completed: false;
 //   Portrait styled cards
 $component-cards-portraits: true;
 //   Header Style Changes

--- a/src/abstract/_config.scss
+++ b/src/abstract/_config.scss
@@ -14,6 +14,8 @@ $abstract-fonts: true;
 $component-button: true;
 //   Cards Style Changes
 $component-cards: true;
+//   Portrait styled cards
+$component-cards-portraits: true;
 //   Header Style Changes
 $component-header: true;
 //   Input Element Style Changes

--- a/src/abstract/_fonts.scss
+++ b/src/abstract/_fonts.scss
@@ -1,13 +1,17 @@
 /** @format */
 
-@import url("https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap");
+@use "../abstract/config" as config;
 
-html,
-body,
-h1,
-h2,
-h2,
-h4,
-h5 {
-	font-family: "Montserrat", sans-serif;
+@if config.$abstract-fonts {
+	@import url("https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap");
+
+	html,
+	body,
+	h1,
+	h2,
+	h2,
+	h4,
+	h5 {
+		font-family: "Montserrat", sans-serif;
+	}
 }

--- a/src/abstract/_mixins.scss
+++ b/src/abstract/_mixins.scss
@@ -1,6 +1,7 @@
 /** @format */
 
 @use "../abstract/variables" as *;
+@use "../abstract/config" as config;
 
 @mixin actorCard($type) {
 	height: auto;
@@ -71,5 +72,11 @@
 		background: $gradient-default;
 		padding: 0.2em;
 		box-shadow: 0 0 5px rgb(0 0 0 / 0.7);
+	}
+
+	@if config.$component-cards-indicator-solid-completed {
+		.playedIndicator {
+			background: $jf-color-completed !important;
+		}
 	}
 }

--- a/src/abstract/_variables.scss
+++ b/src/abstract/_variables.scss
@@ -6,6 +6,7 @@
 	--accent1-light-opacity1: hsla(285, 46%, 56%, 0.4);
 	--accent2-light: hsl(195, 100%, 43%);
 	--accent2-dark: hsl(195, 100%, 16%);
+	--color-completed: hsl(120, 100%, 33.3%);
 }
 $background-dark: hsl(208, 89%, 20%);
 $background-darker: hsl(208, 89%, 5%);
@@ -20,6 +21,7 @@ $jf-purple-light-opacity-1: var(--accent1-light-opacity1);
 $jf-purple-dark: var(--accent1-dark);
 $jf-blue-light: var(--accent2-light);
 $jf-blue-dark: var(--accent2-dark);
+$jf-color-completed: var(--color-completed);
 $gradient-default: linear-gradient(130deg, $jf-purple-light, $jf-blue-light);
 $gradient-icon: linear-gradient(0deg, $jf-purple-light 10%, $jf-blue-light 90%);
 $gradient-dark: linear-gradient(130deg, $jf-purple-dark, $jf-blue-dark);

--- a/src/components/_button.scss
+++ b/src/components/_button.scss
@@ -6,7 +6,7 @@
 @if config.$component-button {
 	.emby-button {
 		position: relative;
-		&[is="emby-button"]:not(.emby-tab-button),
+		&[is="emby-button"]:not(%emby-button-exceptions),
 		&.raised[is="emby-linkbutton"]:not(.emby-tab-button) {
 			background: ab.$background-dark;
 			border-radius: 100vh;
@@ -35,6 +35,18 @@
 			&::after {
 				display: none !important;
 			}
+		}
+	}
+
+	.emby-tab-button {
+		@if config.$pages-titlePage == false {
+			@extend %emby-button-exceptions
+		}
+	}
+
+	.detailButton {
+		@if config.$pages-titlePage == false {
+			@extend %emby-button-exceptions
 		}
 	}
 

--- a/src/components/_button.scss
+++ b/src/components/_button.scss
@@ -1,14 +1,65 @@
 /** @format */
 
 @use "../abstract/variables" as ab;
+@use "../abstract/config" as config;
 
-.emby-button {
-	position: relative;
-	&[is="emby-button"]:not(.emby-tab-button),
-	&.raised[is="emby-linkbutton"]:not(.emby-tab-button) {
-		background: ab.$background-dark;
+@if config.$component-button {
+	.emby-button {
+		position: relative;
+		&[is="emby-button"]:not(.emby-tab-button),
+		&.raised[is="emby-linkbutton"]:not(.emby-tab-button) {
+			background: ab.$background-dark;
+			border-radius: 100vh;
+			overflow: hidden;
+			&::after {
+				content: "";
+				position: absolute;
+				height: 100%;
+				width: 100%;
+				top: 0;
+				left: 0;
+				background: ab.$gradient-default;
+				z-index: -1;
+				opacity: 0;
+				transition: opacity ab.$transition-time-fast-1 linear;
+			}
+			&:hover::after,
+			&:focus::after {
+				opacity: 1;
+			}
+		}
+		&.emby-collapsible-button {
+			box-shadow: none;
+			border: 0 !important;
+			background: transparent !important;
+			&::after {
+				display: none !important;
+			}
+		}
+	}
+
+	.paper-icon-button-light {
+		border-radius: ab.$rounding-default;
+	}
+
+	// Skip Intro
+	.skipIntro,
+	.skip-button {
+		background: ab.$background-dark !important;
 		border-radius: 100vh;
 		overflow: hidden;
+		bottom: 10em;
+		color: white !important;
+		border: none;
+		box-shadow: 0 0 15px black;
+		padding: 0.5em;
+		font-size: 1.2em;
+		right: 1em;
+		position: fixed !important;
+
+		&:hover {
+			box-shadow: 0 0 15px black !important;
+		}
 		&::after {
 			content: "";
 			position: absolute;
@@ -17,68 +68,22 @@
 			top: 0;
 			left: 0;
 			background: ab.$gradient-default;
-			z-index: -1;
+			z-index: 0;
 			opacity: 0;
 			transition: opacity ab.$transition-time-fast-1 linear;
+		}
+		.paper-icon-button-light {
+			z-index: 1;
+			color: white !important;
 		}
 		&:hover::after,
 		&:focus::after {
 			opacity: 1;
 		}
 	}
-	&.emby-collapsible-button {
-		box-shadow: none;
-		border: 0 !important;
-		background: transparent !important;
-		&::after {
-			display: none !important;
-		}
-	}
-}
 
-.paper-icon-button-light {
-	border-radius: ab.$rounding-default;
-}
-
-// Skip Intro
-
-.skipIntro {
-	background: ab.$background-dark !important;
-	border-radius: 100vh;
-	overflow: hidden;
-	bottom: 12em;
-	color: white !important;
-	border: none;
-	box-shadow: 0 0 15px black;
-	padding: 0.5em;
-	font-size: 1.2em;
-	right: 8em;
-
-	&:hover {
-		box-shadow: 0 0 15px black !important;
+	.dialog
+		.emby-button:not(.cardImageContainer, .actionSheetMenuItem).button-delete {
+		background: rgb(247, 0, 0) !important;
 	}
-	&::after {
-		content: "";
-		position: absolute;
-		height: 100%;
-		width: 100%;
-		top: 0;
-		left: 0;
-		background: ab.$gradient-default;
-		z-index: 0;
-		opacity: 0;
-		transition: opacity ab.$transition-time-fast-1 linear;
-	}
-	.paper-icon-button-light {
-		z-index: 1;
-		color: white !important;
-	}
-	&:hover::after,
-	&:focus::after {
-		opacity: 1;
-	}
-}
-.dialog
-	.emby-button:not(.cardImageContainer, .actionSheetMenuItem).button-delete {
-	background: rgb(247, 0, 0) !important;
 }

--- a/src/components/_cards.scss
+++ b/src/components/_cards.scss
@@ -74,47 +74,49 @@
 		&:focus-visible .cardImageContainer::after {
 			transform: scale(1.1);
 		}
-		&.personCard {
-			height: auto;
-			.card {
-				&Padder-overflowPortrait {
-					// padding-bottom: 100% !important;
-					.cardImageIcon {
-						color: transparent !important;
+		@if config.$component-cards-portraits {
+			&.personCard {
+				height: auto;
+				.card {
+					&Padder-overflowPortrait {
+						// padding-bottom: 100% !important;
+						.cardImageIcon {
+							color: transparent !important;
+						}
 					}
-				}
-				&Box {
-					position: relative;
-				}
-				&Overlay {
-					&Container {
-						background: transparent !important;
-						// height: calc(100% - 2.825em);
-						z-index: 3;
+					&Box {
+						position: relative;
 					}
+					&Overlay {
+						&Container {
+							background: transparent !important;
+							// height: calc(100% - 2.825em);
+							z-index: 3;
+						}
 
-					&Button-br {
-						right: 0.5em;
-						bottom: 0.5em;
+						&Button-br {
+							right: 0.5em;
+							bottom: 0.5em;
+						}
 					}
-				}
-				&Content {
-					filter: brightness(1);
-					transition: filter $transition-time-default ease-in-out;
-					$image-margin: 1em;
-					margin: $image-margin !important;
-					width: calc(100% - 2*$image-margin);
-					height: calc(100% - 2*$image-margin);
-					border-radius: 100% !important;
-				}
-				&Scalable {
-					height: auto;
-					aspect-ratio: 1;
-					.cardImageContainer::after {
-						background-size: cover;
+					&Content {
+						filter: brightness(1);
+						transition: filter $transition-time-default ease-in-out;
+						$image-margin: 1em;
+						margin: $image-margin !important;
+						width: calc(100% - 2*$image-margin);
+						height: calc(100% - 2*$image-margin);
+						border-radius: 100% !important;
 					}
-				}
-				&Text {
+					&Scalable {
+						height: auto;
+						aspect-ratio: 1;
+						.cardImageContainer::after {
+							background-size: cover;
+						}
+					}
+					&Text {
+					}
 				}
 			}
 		}

--- a/src/components/_cards.scss
+++ b/src/components/_cards.scss
@@ -1,268 +1,271 @@
 /** @format */
 
 @use "../abstract/variables" as *;
+@use "../abstract/config" as config;
 @use "../abstract/mixins" as *;
 
-.emby-scroller {
-	overflow: visible !important;
-	margin-top: 0.5em;
-}
+@if config.$component-cards {
+	.emby-scroller {
+		overflow: visible !important;
+		margin-top: 0.5em;
+	}
 
-.layout-mobile .emby-scroller{
-	overflow-x: scroll !important;
-}
-.card {
-	contain: none !important;
-	&.overflowSquareCard {
-		.cardScalable {
-			aspect-ratio: 1;
-		}
-		.cardImageContainer {
-			&::after {
-				background-size: contain !important;
-			}
-		}
+	.layout-mobile .emby-scroller{
+		overflow-x: scroll !important;
 	}
-	&OverlayContainer {
-		background: rgb(0 0 0 / 0.7);
-	}
-	&ImageIcon {
-		@include cardIcon();
-	}
-	&Scalable {
-		position: relative;
-		aspect-ratio: auto;
-		overflow: hidden;
-		border-radius: $rounding-default $rounding-default 0 0;
-		box-shadow: none !important;
-		width: calc(100% + 1px);
-
-		& > * {
-			border-radius: 0 !important;
-			width: 100%;
-			box-shadow: none !important;
-		}
-		&:not(.imageEditorCard) .cardImageContainer {
-			&::after,
-			&::before {
-				content: "";
-				position: absolute;
-				background: inherit;
-			}
-			&::after {
-				background-size: cover;
-				width: 100%;
-				height: 100%;
-				left: 0;
-				transform: scale(1);
-				z-index: -1;
-				transition: transform $transition-time-fast-1 ease-in-out;
-			}
-			&::before {
-				filter: blur(5px) brightness(50%);
-				width: calc(100% + 20px);
-				height: calc(100% + 20px);
-				top: -10px;
-				left: -10px;
-				z-index: -1;
-			}
-		}
-	}
-	&:hover .cardImageContainer::after,
-	&:focus-visible .cardImageContainer::after {
-		transform: scale(1.1);
-	}
-	&.personCard {
-		height: auto;
-		.card {
-			&Padder-overflowPortrait {
-				// padding-bottom: 100% !important;
-				.cardImageIcon {
-					color: transparent !important;
-				}
-			}
-			&Box {
-				position: relative;
-			}
-			&Overlay {
-				&Container {
-					background: transparent !important;
-					// height: calc(100% - 2.825em);
-					z-index: 3;
-				}
-
-				&Button-br {
-					right: 0.5em;
-					bottom: 0.5em;
-				}
-			}
-			&Content {
-				filter: brightness(1);
-				transition: filter $transition-time-default ease-in-out;
-				$image-margin: 1em;
-				margin: $image-margin !important;
-				width: calc(100% - 2*$image-margin);
-				height: calc(100% - 2*$image-margin);
-				border-radius: 100% !important;
-			}
-			&Scalable {
-				height: auto;
+	.card {
+		contain: none !important;
+		&.overflowSquareCard {
+			.cardScalable {
 				aspect-ratio: 1;
-				.cardImageContainer::after {
-					background-size: cover;
+			}
+			.cardImageContainer {
+				&::after {
+					background-size: contain !important;
 				}
 			}
-			&Text {
+		}
+		&OverlayContainer {
+			background: rgb(0 0 0 / 0.7);
+		}
+		&ImageIcon {
+			@include cardIcon();
+		}
+		&Scalable {
+			position: relative;
+			aspect-ratio: auto;
+			overflow: hidden;
+			border-radius: $rounding-default $rounding-default 0 0;
+			box-shadow: none !important;
+			width: calc(100% + 1px);
+
+			& > * {
+				border-radius: 0 !important;
+				width: 100%;
+				box-shadow: none !important;
+			}
+			&:not(.imageEditorCard) .cardImageContainer {
+				&::after,
+				&::before {
+					content: "";
+					position: absolute;
+					background: inherit;
+				}
+				&::after {
+					background-size: cover;
+					width: 100%;
+					height: 100%;
+					left: 0;
+					transform: scale(1);
+					z-index: -1;
+					transition: transform $transition-time-fast-1 ease-in-out;
+				}
+				&::before {
+					filter: blur(5px) brightness(50%);
+					width: calc(100% + 20px);
+					height: calc(100% + 20px);
+					top: -10px;
+					left: -10px;
+					z-index: -1;
+				}
 			}
 		}
-	}
-	&Box {
-		$card-padding: 1.5em;
-		margin: 0.5em $card-padding $card-padding 0 !important;
-		box-shadow: 0 0 0.5em rgb(0 0 0 / 0.75);
-		background: rgb(0 0 0 / 0.2);
-		border-radius: $rounding-default;
-		overflow: hidden;
-		transition: background $transition-time-fast-1;
-	}
-	&:not([data-type="Person"]) .cardText-secondary {
-		padding-bottom: 0.5em;
-	}
-	&:hover .cardBox,
-	&:focus-visible .cardBox {
-		background: rgb(0 0 0 / 0.5);
-	}
-	&.squareCard .cardScalable {
-		width: 100%;
-		padding-top: 100%;
-	}
-}
-.card[data-userid] .cardScalable {
-	padding-top: 0 !important;
-	.cardContent {
-		padding-top: 100% !important;
-	}
-}
-.cardPadder {
-	background: transparent !important;
-	&-square {
-		aspect-ratio: 0 !important;
-		padding: 0;
-	}
-	&-square + div {
-		aspect-ratio: 1;
-	}
-}
-.cardImageContainer {
-	&.defaultCardBackground {
-		background: transparent;
-	}
-}
-.innerCardFooter {
-	width: 90%;
-	margin-bottom: 5%;
-	margin-left: auto;
-	margin-right: auto;
-	border-radius: $rounding-default;
-	.itemProgressBar {
-		background: rgb(255 255 255/0.3);
-		height: 0.4em;
-		.itemProgressBarForeground {
-			background: $gradient-default;
+		&:hover .cardImageContainer::after,
+		&:focus-visible .cardImageContainer::after {
+			transform: scale(1.1);
+		}
+		&.personCard {
+			height: auto;
+			.card {
+				&Padder-overflowPortrait {
+					// padding-bottom: 100% !important;
+					.cardImageIcon {
+						color: transparent !important;
+					}
+				}
+				&Box {
+					position: relative;
+				}
+				&Overlay {
+					&Container {
+						background: transparent !important;
+						// height: calc(100% - 2.825em);
+						z-index: 3;
+					}
+
+					&Button-br {
+						right: 0.5em;
+						bottom: 0.5em;
+					}
+				}
+				&Content {
+					filter: brightness(1);
+					transition: filter $transition-time-default ease-in-out;
+					$image-margin: 1em;
+					margin: $image-margin !important;
+					width: calc(100% - 2*$image-margin);
+					height: calc(100% - 2*$image-margin);
+					border-radius: 100% !important;
+				}
+				&Scalable {
+					height: auto;
+					aspect-ratio: 1;
+					.cardImageContainer::after {
+						background-size: cover;
+					}
+				}
+				&Text {
+				}
+			}
+		}
+		&Box {
+			$card-padding: 1.5em;
+			margin: 0.5em $card-padding $card-padding 0 !important;
+			box-shadow: 0 0 0.5em rgb(0 0 0 / 0.75);
+			background: rgb(0 0 0 / 0.2);
+			border-radius: $rounding-default;
+			overflow: hidden;
+			transition: background $transition-time-fast-1;
+		}
+		&:not([data-type="Person"]) .cardText-secondary {
+			padding-bottom: 0.5em;
+		}
+		&:hover .cardBox,
+		&:focus-visible .cardBox {
+			background: rgb(0 0 0 / 0.5);
+		}
+		&.squareCard .cardScalable {
+			width: 100%;
+			padding-top: 100%;
 		}
 	}
-}
-.cardOverlayContainer {
-	display: flex;
-	flex-flow: column;
-	flex-direction: column;
-	flex-wrap: nowrap;
-	align-content: center;
-	justify-content: center;
-	align-items: center;
-}
-
-.cardOverlayButton {
-	border-radius: 100px !important;
-	span {
-		background: $gradient-icon !important;
-		background-clip: text !important;
-		-webkit-background-clip: text !important;
-		transition: $transition-time-fast-1;
-	}
-	&[data-action="resume"] {
-		border-radius: 1000px;
-		padding: 1.5em;
-		background: $gradient-default !important;
-		color: white !important;
-		&:hover,
-		&:focus-visible {
-			filter: brightness(0.5);
+	.card[data-userid] .cardScalable {
+		padding-top: 0 !important;
+		.cardContent {
+			padding-top: 100% !important;
 		}
-	}
-	&:hover,
-	&:focus-visible {
-		transform: scale(1) !important;
-	}
-}
-.cardIndicators,
-.listItemIndicators {
-	@include indicator();
-}
-[data-isfolder="true"]:is(
-		[data-type="CollectionFolder"],
-		[data-type="UserView"]
-	):not([data-type="Series"])
-	.cardText {
-	padding: 0.75em !important;
-}
-[data-collectiontype="livetv"] .cardText {
-	padding: 0.75em !important;
-}
-.cardText:nth-child(4) {
-	display: none;
-}
-.defaultCardBackground {
-	background: $gradient-dark !important;
-}
-.chapterCard .innerCardFooter {
-	backdrop-filter: blur(5px);
-	background: rgb(0 0 0 / 0.6);
-	border-radius: 0 1em 1em 0 !important;
-}
-
-.layout-mobile .cardOverlayButton {
-	width: fit-content;
-	background: rgb(0 0 0 / 0.5);
-	backdrop-filter: blur(5px);
-	border-radius: $rounding-default !important;
-	bottom: 10px;
-	right: 10px;
-}
-.devicesList {
-	.cardScalable {
-		aspect-ratio: 16/9;
 	}
 	.cardPadder {
+		background: transparent !important;
+		&-square {
+			aspect-ratio: 0 !important;
+			padding: 0;
+		}
+		&-square + div {
+			aspect-ratio: 1;
+		}
+	}
+	.cardImageContainer {
+		&.defaultCardBackground {
+			background: transparent;
+		}
+	}
+	.innerCardFooter {
+		width: 90%;
+		margin-bottom: 5%;
+		margin-left: auto;
+		margin-right: auto;
+		border-radius: $rounding-default;
+		.itemProgressBar {
+			background: rgb(255 255 255/0.3);
+			height: 0.4em;
+			.itemProgressBarForeground {
+				background: $jf-blue-light;
+			}
+		}
+	}
+	.cardOverlayContainer {
+		display: flex;
+		flex-flow: column;
+		flex-direction: column;
+		flex-wrap: nowrap;
+		align-content: center;
+		justify-content: center;
+		align-items: center;
+	}
+
+	.cardOverlayButton {
+		border-radius: 100px !important;
+		span {
+			background: $gradient-icon !important;
+			background-clip: text !important;
+			-webkit-background-clip: text !important;
+			transition: $transition-time-fast-1;
+		}
+		&[data-action="resume"] {
+			border-radius: 1000px;
+			padding: 1.5em;
+			background: $gradient-default !important;
+			color: white !important;
+			&:hover,
+			&:focus-visible {
+				filter: brightness(0.5);
+			}
+		}
+		&:hover,
+		&:focus-visible {
+			transform: scale(1) !important;
+		}
+	}
+	.cardIndicators,
+	.listItemIndicators {
+		@include indicator();
+	}
+	[data-isfolder="true"]:is(
+			[data-type="CollectionFolder"],
+			[data-type="UserView"]
+		):not([data-type="Series"])
+		.cardText {
+		padding: 0.75em !important;
+	}
+	[data-collectiontype="livetv"] .cardText {
+		padding: 0.75em !important;
+	}
+	.cardText:nth-child(4) {
 		display: none;
 	}
-}
+	.defaultCardBackground {
+		background: $gradient-dark !important;
+	}
+	.chapterCard .innerCardFooter {
+		backdrop-filter: blur(5px);
+		background: rgb(0 0 0 / 0.6);
+		border-radius: 0 1em 1em 0 !important;
+	}
 
-// commandPanel Selected card border
+	.layout-mobile .cardOverlayButton {
+		width: fit-content;
+		background: rgb(0 0 0 / 0.5);
+		backdrop-filter: blur(5px);
+		border-radius: $rounding-default !important;
+		bottom: 10px;
+		right: 10px;
+	}
+	.devicesList {
+		.cardScalable {
+			aspect-ratio: 16/9;
+		}
+		.cardPadder {
+			display: none;
+		}
+	}
 
-.itemSelectionPanel {
-	border: 1px solid $jf-purple-light;
-	border-radius: 10px;
-	overflow: hidden;
-	padding: 0.5em;
-	background: linear-gradient(to bottom, rgb(0 0 0 / 0.75), transparent 21%);
-}
+	// commandPanel Selected card border
 
-// Fix image duplication in dialog cards
+	.itemSelectionPanel {
+		border: 1px solid $jf-purple-light;
+		border-radius: 10px;
+		overflow: hidden;
+		padding: 0.5em;
+		background: linear-gradient(to bottom, rgb(0 0 0 / 0.75), transparent 21%);
+	}
 
-.dialogContainer .card {
-	.cardImageContainer::before,
-	.cardImageContainer::after {
-		display: none !important;
+	// Fix image duplication in dialog cards
+
+	.dialogContainer .card {
+		.cardImageContainer::before,
+		.cardImageContainer::after {
+			display: none !important;
+		}
 	}
 }

--- a/src/components/_header.scss
+++ b/src/components/_header.scss
@@ -1,56 +1,59 @@
 /** @format */
 
 @use "../abstract/variables" as *;
+@use "../abstract/config" as config;
 
-.skinHeader {
-	background: transparent !important;
-	position: static;
-}
+@if config.$component-header {
+	.skinHeader {
+		background: transparent !important;
+		position: static;
+	}
 
-.layout-mobile,
-.layout-desktop {
-	body {
+	.layout-mobile,
+	.layout-desktop {
+		body {
+			display: flex;
+			flex-direction: column;
+			flex-wrap: nowrap;
+			overflow: hidden !important;
+		}
+	}
+
+	div#reactRoot {
+		height: 100vh;
 		display: flex;
 		flex-direction: column;
-		flex-wrap: nowrap;
-		overflow: hidden !important;
 	}
-}
 
-div#reactRoot {
-	height: 100vh;
-	display: flex;
-	flex-direction: column;
-}
-
-div[data-role="page"].page {
-	position: absolute;
-	overflow: hidden visible;
-	mask-image: linear-gradient(
-		to top,
-		black 1em calc(100% - 2em),
-		transparent
-	);
-	-webkit-mask-image: linear-gradient(
-		to top,
-		black 1em calc(100% - 2em),
-		transparent
-	);
-	padding: 2em 0 !important;
-	&#searchPage {
-		margin-top: 4.4em;
+	div[data-role="page"].page {
+		position: absolute;
+		overflow: hidden visible;
+		mask-image: linear-gradient(
+			to top,
+			black 1em calc(100% - 2em),
+			transparent
+		);
+		-webkit-mask-image: linear-gradient(
+			to top,
+			black 1em calc(100% - 2em),
+			transparent
+		);
+		padding: 2em 0 !important;
+		&#searchPage {
+			margin-top: 4.4em;
+		}
 	}
-}
 
-.mainAnimatedPages.skinBody {
-	height: 100%;
-	position: relative;
-}
+	.mainAnimatedPages.skinBody {
+		height: 100%;
+		position: relative;
+	}
 
-// Command Panel
+	// Command Panel
 
-.selectionCommandsPanel {
-	background: rgb(0 0 0 / 0.75);
-	backdrop-filter: blur($filter-blur-default);
-	box-shadow: 0 0 15px black;
+	.selectionCommandsPanel {
+		background: rgb(0 0 0 / 0.75);
+		backdrop-filter: blur($filter-blur-default);
+		box-shadow: 0 0 15px black;
+	}
 }

--- a/src/components/_input.scss
+++ b/src/components/_input.scss
@@ -1,144 +1,148 @@
 /** @format */
 
 @use "../abstract/variables" as *;
-// Textbox
-.inputContainer {
-	position: relative;
-	.inputLabel {
-		top: -1.2em;
-		font-size: 0.95em;
-		position: absolute;
-		transition: top $transition-time-default,
-			font-size $transition-time-default;
-		&-float:not(&Focused) {
-			font-size: 1.2em;
-			top: 0;
+@use "../abstract/config" as config;
+
+@if config.$component-input {
+	// Textbox
+	.inputContainer {
+		position: relative;
+		.inputLabel {
+			top: -1.2em;
+			font-size: 0.95em;
+			position: absolute;
+			transition: top $transition-time-default,
+				font-size $transition-time-default;
+			&-float:not(&Focused) {
+				font-size: 1.2em;
+				top: 0;
+			}
+		}
+		.emby-input {
+			background: transparent;
+			border: none;
+			border-bottom: 0.1em solid rgba(255, 255, 255, 0.7);
+			border-radius: 0 !important;
+			&:focus {
+				border-color: $jf-blue-light !important;
+			}
 		}
 	}
-	.emby-input {
+
+	// Selectbox
+	.emby-select {
 		background: transparent;
-		border: none;
-		border-bottom: 0.1em solid rgba(255, 255, 255, 0.7);
+		border: none !important;
+		border-bottom: 0.1em solid rgba(255, 255, 255, 0.7) !important;
 		border-radius: 0 !important;
 		&:focus {
 			border-color: $jf-blue-light !important;
 		}
 	}
-}
-
-// Selectbox
-.emby-select {
-	background: transparent;
-	border: none !important;
-	border-bottom: 0.1em solid rgba(255, 255, 255, 0.7) !important;
-	border-radius: 0 !important;
-	&:focus {
-		border-color: $jf-blue-light !important;
+	.emby-select:focus ~ .selectArrowContainer {
+		transform: rotate(180deg);
 	}
-}
-.emby-select:focus ~ .selectArrowContainer {
-	transform: rotate(180deg);
-}
-.selectArrowContainer {
-	transition: transform $transition-time-fast-1;
-}
-
-// Checkbox
-.checkbox {
-	&Outline {
-		background-color: hsl(208deg, 89%, 20%) !important;
-		border-color: hsl(208deg, 89%, 20%) !important;
-		border-radius: 5px !important;
-		/* align-items: center; */
-		/* justify-content: center; */
+	.selectArrowContainer {
+		transition: transform $transition-time-fast-1;
 	}
-}
-span.checkboxLabel {
-	position: relative;
-	&::after {
-		content: "";
-		position: absolute;
-		height: 0.1em;
+
+	// Checkbox
+	.checkbox {
+		&Outline {
+			background-color: hsl(208deg, 89%, 20%) !important;
+			border-color: hsl(208deg, 89%, 20%) !important;
+			border-radius: 5px !important;
+			/* align-items: center; */
+			/* justify-content: center; */
+		}
+	}
+	span.checkboxLabel {
+		position: relative;
+		&::after {
+			content: "";
+			position: absolute;
+			height: 0.1em;
+			width: 100%;
+			transform: scaleX(0);
+			transform-origin: left;
+			transition: transform $transition-time-default ease-in-out;
+			left: 0;
+			bottom: -0.2em;
+			background-color: white;
+		}
+	}
+	.emby-checkbox:focus-visible + span.checkboxLabel::after {
+		transform: scaleX(1);
+	}
+	.checkboxIcon-checked,
+	.emby-checkbox-label .checkboxIcon-checked {
+		display: block !important;
+		opacity: 0;
+		transform: rotate(45deg) scale(0);
+		align-items: center;
+		justify-content: center;
+		transition: transform $transition-time-fast-1,
+			opacity $transition-time-fast-1;
+	}
+	.emby-checkbox:checked + span + .checkboxOutline > .checkboxIcon-checked {
+		display: -webkit-flex !important;
+		display: flex !important;
+		opacity: 1;
+		transform: rotate(0deg) scale(1);
+	}
+
+	// Textarea
+	.emby-textarea {
+		background: transparent;
+		border: none;
+		border-bottom: 0.1em solid rgba(255, 255, 255, 0.7);
+		border-radius: 0 !important;
 		width: 100%;
-		transform: scaleX(0);
-		transform-origin: left;
-		transition: transform $transition-time-default ease-in-out;
-		left: 0;
-		bottom: -0.2em;
-		background-color: white;
-	}
-}
-.emby-checkbox:focus-visible + span.checkboxLabel::after {
-	transform: scaleX(1);
-}
-.checkboxIcon-checked,
-.emby-checkbox-label .checkboxIcon-checked {
-	display: block !important;
-	opacity: 0;
-	transform: rotate(45deg) scale(0);
-	align-items: center;
-	justify-content: center;
-	transition: transform $transition-time-fast-1,
-		opacity $transition-time-fast-1;
-}
-.emby-checkbox:checked + span + .checkboxOutline > .checkboxIcon-checked {
-	display: -webkit-flex !important;
-	display: flex !important;
-	opacity: 1;
-	transform: rotate(0deg) scale(1);
-}
-
-// Textarea
-.emby-textarea {
-	background: transparent;
-	border: none;
-	border-bottom: 0.1em solid rgba(255, 255, 255, 0.7);
-	border-radius: 0 !important;
-	width: 100%;
-	&:focus {
-		border-color: $jf-blue-light !important;
-	}
-}
-
-// Checkbox and Paper list
-
-.checkboxList.paperList {
-	background: rgb(0 0 0 / 0.5) !important;
-	overflow: auto !important;
-	border-radius: $rounding-default !important;
-}
-
-.paperList {
-	overflow: hidden;
-	border-radius: $rounding-max;
-	background: transparent !important;
-	.listItem {
-		transition: background $transition-time-default;
-		background: rgb(0 0 0 / 0.5);
-		border: none !important;
-		border-radius: $rounding--1;
-		margin-bottom: 0.3em;
-		&:last-child {
-			border: none;
-			margin-bottom: 0 !important;
-		}
-		&:hover,
-		&:focus-visible {
-			background: rgb(0 0 0 / 0.7);
-		}
-		&Icon {
-			background: $gradient-default;
-			color: transparent;
-			background-clip: text;
-			-webkit-background-clip: text;
+		&:focus {
+			border-color: $jf-blue-light !important;
 		}
 	}
-}
 
-// Fix focus color of inputs
+	// Checkbox and Paper list
 
-.inputLabelFocused,
-.selectLabelFocused,
-.textareaLabelFocused {
-	color: $jf-blue-light;
+	.checkboxList.paperList {
+		background: rgb(0 0 0 / 0.5) !important;
+		overflow: auto !important;
+		border-radius: $rounding-default !important;
+	}
+
+	.paperList {
+		overflow: hidden;
+		border-radius: $rounding-max;
+		background: transparent !important;
+		.listItem {
+			transition: background $transition-time-default;
+			background: rgb(0 0 0 / 0.5);
+			border: none !important;
+			border-radius: $rounding--1;
+			margin-bottom: 0.3em;
+			&:last-child {
+				border: none;
+				margin-bottom: 0 !important;
+			}
+			&:hover,
+			&:focus-visible {
+				background: rgb(0 0 0 / 0.7);
+			}
+			&Icon {
+				background: $gradient-default;
+				color: transparent;
+				background-clip: text;
+				-webkit-background-clip: text;
+			}
+		}
+	}
+
+	// Fix focus color of inputs
+
+	.inputLabelFocused,
+	.selectLabelFocused,
+	.textareaLabelFocused {
+		color: $jf-blue-light;
+	}
 }

--- a/src/components/_links.scss
+++ b/src/components/_links.scss
@@ -1,26 +1,30 @@
 /** @format */
 @use "../abstract/variables" as *;
-a[is="emby-linkbutton"]:not(.listItem-border, .navMenuOption) {
-	position: relative;
-	margin-bottom: 0.3em;
-	text-decoration: none !important;
-	&.button-link {
-		color: $jf-blue-light;
-	}
-	&::after {
-		content: "" !important;
-		position: absolute;
-		left: 0 !important;
-		bottom: -0.1em;
-		width: 100%;
-		height: 0.1em;
-		background: currentColor;
-		transform-origin: right;
-		transform: scale(0);
-		transition: transform $transition-time-fast-1 ease-in-out;
-	}
-	&:hover::after {
-		transform-origin: left;
-		transform: scale(1);
+@use "../abstract/config" as config;
+
+@if config.$component-links {
+	a[is="emby-linkbutton"]:not(.listItem-border, .navMenuOption) {
+		position: relative;
+		margin-bottom: 0.3em;
+		text-decoration: none !important;
+		&.button-link {
+			color: $jf-blue-light;
+		}
+		&::after {
+			content: "" !important;
+			position: absolute;
+			left: 0 !important;
+			bottom: -0.1em;
+			width: 100%;
+			height: 0.1em;
+			background: currentColor;
+			transform-origin: right;
+			transform: scale(0);
+			transition: transform $transition-time-fast-1 ease-in-out;
+		}
+		&:hover::after {
+			transform-origin: left;
+			transform: scale(1);
+		}
 	}
 }

--- a/src/components/_menu.scss
+++ b/src/components/_menu.scss
@@ -1,66 +1,70 @@
 /** @format */
 
 @use "../abstract/variables" as *;
-// myPreferencesMenuPage
-#myPreferencesMenuPage {
-	.listItem {
-		border-radius: $rounding-default;
-		transition: background $transition-time-default;
-		&:hover {
-			background: black;
-			.listItemIcon {
-				margin-right: 0.5em;
+@use "../abstract/config" as config;
+
+@if config.$component-menu {
+	// myPreferencesMenuPage
+	#myPreferencesMenuPage {
+		.listItem {
+			border-radius: $rounding-default;
+			transition: background $transition-time-default;
+			&:hover {
+				background: black;
+				.listItemIcon {
+					margin-right: 0.5em;
+				}
+			}
+			&-border {
+				border: none !important;
+			}
+			&Icon {
+				background: $gradient-default;
+				color: transparent;
+				background-clip: text;
+				-webkit-background-clip: text;
+				transition: margin-right $transition-time-default;
 			}
 		}
-		&-border {
-			border: none !important;
-		}
-		&Icon {
-			background: $gradient-default;
-			color: transparent;
-			background-clip: text;
-			-webkit-background-clip: text;
-			transition: margin-right $transition-time-default;
-		}
 	}
-}
 
-//dialog
-.dialog {
-	background: rgba(0, 0, 0, 0.4);
-	border-radius: 15px !important;
-	overflow: hidden;
-	backdrop-filter: blur($filter-blur-default);
-	.smoothScrollY {
-		max-height: 100%;
-	}
-	.emby-button:not(.cardImageContainer, .actionSheetMenuItem) {
-		background: rgb(0 0 0 / 0) !important;
-		&::after {
-			all: unset !important;
+	//dialog
+	.dialog {
+		background: rgba(0, 0, 0, 0.4);
+		border-radius: 15px !important;
+		overflow: hidden;
+		backdrop-filter: blur($filter-blur-default);
+		.smoothScrollY {
+			max-height: 100%;
+		}
+		.emby-button:not(.cardImageContainer, .actionSheetMenuItem) {
+			background: rgb(0 0 0 / 0) !important;
+			&::after {
+				all: unset !important;
+			}
+		}
+		.emby-button.actionSheetMenuItem {
+			background: transparent !important;
+		}
+		.cardText {
+			display: block !important;
+		}
+		.actionSheetContent {
+			margin: 10px !important;
+			padding: 0 !important;
+		}
+		.actionSheetScroller{
+			mask-image: none !important;
+			-webkit-mask-image: none !important;
+			padding: 0 !important;
+		}
+		.actionSheetMenuItem{
+			border-radius: 5px !important;
 		}
 	}
-	.emby-button.actionSheetMenuItem {
-		background: transparent !important;
-	}
-	.cardText {
-		display: block !important;
-	}
-	.actionSheetContent {
-		margin: 10px !important;
-		padding: 0 !important;
-	}
-	.actionSheetScroller{
-		mask-image: none !important;
-		-webkit-mask-image: none !important;
-		padding: 0 !important;
-	}
-	.actionSheetMenuItem{
-		border-radius: 5px !important;
-	}
-}
 
-.filterDialogContent {
-	height: 100%;
-	overflow: auto;
+	.filterDialogContent {
+		height: 100%;
+		overflow: auto;
+	}
 }

--- a/src/components/_scrollbars.scss
+++ b/src/components/_scrollbars.scss
@@ -1,10 +1,14 @@
-// side menu
-.mainDrawer.drawer-open .scrollContainer{
-    &::-webkit-scrollbar{
-        &-track{
-            box-shadow: none !important;
-            &-piece{
-                background: transparent !important;
+@use "../abstract/config" as config;
+
+@if config.$component-scrollbars {
+    // side menu
+    .mainDrawer.drawer-open .scrollContainer{
+        &::-webkit-scrollbar{
+            &-track{
+                box-shadow: none !important;
+                &-piece{
+                    background: transparent !important;
+                }
             }
         }
     }

--- a/src/components/_sidemenu.scss
+++ b/src/components/_sidemenu.scss
@@ -1,52 +1,56 @@
 /** @format */
 
 @use "../abstract/variables" as *;
-:not(.dashboardDocument) .mainDrawer {
-	background: rgb(0 0 0 / 0.5);
-	backdrop-filter: blur(0);
+@use "../abstract/config" as config;
 
-	&.drawer-open {
-		backdrop-filter: blur($filter-blur-default + 10px);
-		.scrollContainer {
-			mask-image: linear-gradient(
-				to top,
-				transparent,
-				black 0.5em calc(100% - 0.5em),
-				transparent
-			);
-			-webkit-mask-image: linear-gradient(
-				to top,
-				transparent,
-				black 0.5em calc(100% - 0.5em),
-				transparent
-			);
-		}
-	}
-	.navMenuOption {
-		&::after {
-			content: "";
-			position: absolute;
-			height: 100%;
-			width: 100%;
-			top: 0;
-			left: 0;
-			background: $gradient-default;
-			z-index: -1;
-			opacity: 0;
-			transition: opacity $transition-time-fast-1 linear;
-		}
-		.navMenuOptionIcon {
-			transition: margin-right $transition-time-fast-1 linear;
-		}
-		&-selected {
-			background: $gradient-default-inverted !important;
-		}
-		&:hover {
-			.navMenuOptionIcon {
-				margin-right: 1.46em;
+@if config.$component-sidemenu {
+	:not(.dashboardDocument) .mainDrawer {
+		background: rgb(0 0 0 / 0.5);
+		backdrop-filter: blur(0);
+
+		&.drawer-open {
+			backdrop-filter: blur($filter-blur-default + 10px);
+			.scrollContainer {
+				mask-image: linear-gradient(
+					to top,
+					transparent,
+					black 0.5em calc(100% - 0.5em),
+					transparent
+				);
+				-webkit-mask-image: linear-gradient(
+					to top,
+					transparent,
+					black 0.5em calc(100% - 0.5em),
+					transparent
+				);
 			}
+		}
+		.navMenuOption {
 			&::after {
-				opacity: 1;
+				content: "";
+				position: absolute;
+				height: 100%;
+				width: 100%;
+				top: 0;
+				left: 0;
+				background: $gradient-default;
+				z-index: -1;
+				opacity: 0;
+				transition: opacity $transition-time-fast-1 linear;
+			}
+			.navMenuOptionIcon {
+				transition: margin-right $transition-time-fast-1 linear;
+			}
+			&-selected {
+				background: $gradient-default-inverted !important;
+			}
+			&:hover {
+				.navMenuOptionIcon {
+					margin-right: 1.46em;
+				}
+				&::after {
+					opacity: 1;
+				}
 			}
 		}
 	}

--- a/src/components/_sliderBubble.scss
+++ b/src/components/_sliderBubble.scss
@@ -1,18 +1,22 @@
 /** @format */
 
 @use "../abstract/variables" as *;
-.sliderBubble {
-	border-radius: $rounding-max;
-	overflow: hidden;
-	background: transparent;
-}
+@use "../abstract/config" as config;
 
-.chapterThumbTextContainer {
-	background: linear-gradient(
-		to top,
-		black 0.25em,
-		rgb(0 0 0 /0.25),
-		transparent
-	) !important;
-	padding: 0.5em 0.25em 0.5em !important;
+@if config.$component-sliderBubble {
+	.sliderBubble {
+		border-radius: $rounding-max;
+		overflow: hidden;
+		background: transparent;
+	}
+
+	.chapterThumbTextContainer {
+		background: linear-gradient(
+			to top,
+			black 0.25em,
+			rgb(0 0 0 /0.25),
+			transparent
+		) !important;
+		padding: 0.5em 0.25em 0.5em !important;
+	}
 }

--- a/src/pages/_dashboard.scss
+++ b/src/pages/_dashboard.scss
@@ -1,43 +1,47 @@
 /** @format */
 
-@media (min-width: 40em) {
-	.dashboardDocument .skinBody {
-		width: calc(100% - 20em);
+@use "../abstract/config" as config;
+
+@if config.$pages-dashboard {
+	@media (min-width: 40em) {
+		.dashboardDocument .skinBody {
+			width: calc(100% - 20em);
+		}
 	}
-}
 
-.dashboardDocument .headerTabs {
-	margin-left: 0;
-	width: auto;
-}
-
-.dashboardColumn:first-child .dashboardSection .paperList {
-	background: rgb(0 0 0 / 0.5) !important;
-	font-size: 1.1em;
-	color: rgb(255 255 255 / 0.7);
-}
-
-.layout-mobile .dashboardDocument .headerTabs {
-	width: 100%;
-}
-
-.MuiBox-root{
-	.mainAnimatedPages {
-		width: 100%;
-		height: auto;
-		overflow: visible;
+	.dashboardDocument .headerTabs {
+		margin-left: 0;
+		width: auto;
 	}
-}
 
-body.dashboardDocument{
-	overflow: auto !important;
-	div[data-role="page"]{
-		position: relative !important;
+	.dashboardColumn:first-child .dashboardSection .paperList {
+		background: rgb(0 0 0 / 0.5) !important;
+		font-size: 1.1em;
+		color: rgb(255 255 255 / 0.7);
+	}
+
+	.layout-mobile .dashboardDocument .headerTabs {
 		width: 100%;
-		height: fit-content;
-		overflow: visible;
-		mask-image: none !important;
-		-webkit-mask-image: none !important;
-		left: 0 !important;
+	}
+
+	.MuiBox-root{
+		.mainAnimatedPages {
+			width: 100%;
+			height: auto;
+			overflow: visible;
+		}
+	}
+
+	body.dashboardDocument{
+		overflow: auto !important;
+		div[data-role="page"]{
+			position: relative !important;
+			width: 100%;
+			height: fit-content;
+			overflow: visible;
+			mask-image: none !important;
+			-webkit-mask-image: none !important;
+			left: 0 !important;
+		}
 	}
 }

--- a/src/pages/_indexPage.scss
+++ b/src/pages/_indexPage.scss
@@ -1,43 +1,47 @@
 /** @format */
 
 @use "../abstract/variables" as ab;
-#indexPage {
-	.sectionTitle {
-		display: flex;
-		flex-direction: row;
-		flex-wrap: nowrap;
-		color: white;
-		align-items: center;
-		font-size: 1.6em;
-		&::before {
-			content: "";
-			margin-right: 0.5em;
-			width: 1.3em;
-			height: 2px;
-			background: white;
-		}
-	}
-	.emby-scroller {
-		.emby-button:not(.cardOverlayButton) {
-			margin-right: 1.2em;
-			border-radius: ab.$rounding-default;
-			background: rgb(0 0 0 / 0.2);
-			box-shadow: 0 0 0.5em rgb(0 0 0 / 0.75);
-			overflow: hidden;
-			&::after {
-				all: unset;
-			}
-			&:hover {
-				background: rgb(0 0 0 / 0.5);
+@use "../abstract/config" as config;
+
+@if config.$pages-indexPage {
+	#indexPage {
+		.sectionTitle {
+			display: flex;
+			flex-direction: row;
+			flex-wrap: nowrap;
+			color: white;
+			align-items: center;
+			font-size: 1.6em;
+			&::before {
+				content: "";
+				margin-right: 0.5em;
+				width: 1.3em;
+				height: 2px;
+				background: white;
 			}
 		}
-	}
-	.section0 {
-		.emby-scrollbuttons {
-			display: none;
+		.emby-scroller {
+			.emby-button:not(.cardOverlayButton) {
+				margin-right: 1.2em;
+				border-radius: ab.$rounding-default;
+				background: rgb(0 0 0 / 0.2);
+				box-shadow: 0 0 0.5em rgb(0 0 0 / 0.75);
+				overflow: hidden;
+				&::after {
+					all: unset;
+				}
+				&:hover {
+					background: rgb(0 0 0 / 0.5);
+				}
+			}
 		}
-		.itemsContainer {
-			flex-wrap: wrap;
+		.section0 {
+			.emby-scrollbuttons {
+				display: none;
+			}
+			.itemsContainer {
+				flex-wrap: wrap;
+			}
 		}
 	}
 }

--- a/src/pages/_loginPage.scss
+++ b/src/pages/_loginPage.scss
@@ -1,66 +1,70 @@
 /** @format */
 
-#loginPage {
-	mask-image: none;
-	-webkit-mask-image: none;
-	&:after {
-		content: "";
-		width: 100vw;
-		height: 100vh;
-		position: fixed;
-		top: 0;
-		left: 0;
-		background: url("https://cdn.jsdelivr.net/gh/prayag17/JellySkin/src/assets/background.png");
-		background-size: cover;
-		z-index: -1;
-	}
-	& > div {
-		position: absolute;
-		top: 50%;
-		left: 50%;
-		transform: translate(-50%, -50%);
-		padding: 0 !important;
-		min-width: 40vw;
-		max-width: 50vw;
-		z-index: 2;
-	}
-	#divUsers {
-		flex-wrap: nowrap;
-		justify-content: flex-start;
-		overflow: auto;
-		.card {
-			width: 30%;
-			.cardBox {
-				box-shadow: none !important;
+@use "../abstract/config" as config;
+
+@if config.$pages-loginPage {
+	#loginPage {
+		mask-image: none;
+		-webkit-mask-image: none;
+		&:after {
+			content: "";
+			width: 100vw;
+			height: 100vh;
+			position: fixed;
+			top: 0;
+			left: 0;
+			background: url("https://cdn.jsdelivr.net/gh/prayag17/JellySkin/src/assets/background.png");
+			background-size: cover;
+			z-index: -1;
+		}
+		& > div {
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			transform: translate(-50%, -50%);
+			padding: 0 !important;
+			min-width: 40vw;
+			max-width: 50vw;
+			z-index: 2;
+		}
+		#divUsers {
+			flex-wrap: nowrap;
+			justify-content: flex-start;
+			overflow: auto;
+			.card {
+				width: 30%;
+				.cardBox {
+					box-shadow: none !important;
+				}
 			}
 		}
-	}
-	.emby-button {
-		background: transparent;
-		border: 0.2em solid;
-		&::after {
-			all: unset !important;
+		.emby-button {
+			background: transparent;
+			border: 0.2em solid;
+			&::after {
+				all: unset !important;
+			}
+			&:hover,
+			&:focus-visible {
+				background: rgb(255 255 255 / 0.2);
+			}
 		}
-		&:hover,
-		&:focus-visible {
-			background: rgb(255 255 255 / 0.2);
+		.checkboxOutline {
+			background: transparent !important;
+			border: 0.152em solid white !important;
+		}
+		.inputLabelFocused,
+		.emby-input:focus {
+			color: white !important;
+			border-bottom-color: white !important;
 		}
 	}
-	.checkboxOutline {
-		background: transparent !important;
-		border: 0.152em solid white !important;
-	}
-	.inputLabelFocused,
-	.emby-input:focus {
-		color: white !important;
-		border-bottom-color: white !important;
-	}
-}
 
-// mobile
-.layout-mobile #loginPage {
-	& > div {
-		width: 85vw;
-		max-width: 85vw;
+	// mobile
+	.layout-mobile #loginPage {
+		& > div {
+			width: 85vw;
+			max-width: 85vw;
+		}
 	}
 }

--- a/src/pages/_player.scss
+++ b/src/pages/_player.scss
@@ -1,40 +1,43 @@
 /** @format */
 @use "../abstract/variables" as *;
+@use "../abstract/config" as config;
 
-@media (orientation: portrait) and (max-width: 43em) {
+@if config.$pages-player {
+	@media (orientation: portrait) and (max-width: 43em) {
+		.nowPlaying {
+			&InfoContainer {
+				justify-content: center;
+				align-items: center;
+			}
+			&PageImageContainer {
+				flex-grow: 0;
+			}
+		}
+	}
+
 	.nowPlaying {
-		&InfoContainer {
-			justify-content: center;
-			align-items: center;
-		}
-		&PageImageContainer {
-			flex-grow: 0;
+		&SongName {
+			font-size: 1.5em;
+			white-space: nowrap;
+			text-overflow: ellipsis;
 		}
 	}
-}
 
-.nowPlaying {
-	&SongName {
-		font-size: 1.5em;
-		white-space: nowrap;
-		text-overflow: ellipsis;
+	.subtitleSync {
+		top: 8em;
+		left: 0;
+		&Container {
+			background-color: rgb(0 0 0 / 0.75);
+			backdrop-filter: blur($filter-blur-default);
+		}
 	}
-}
 
-.subtitleSync {
-	top: 8em;
-	left: 0;
-	&Container {
-		background-color: rgb(0 0 0 / 0.75);
+	.sliderBubble {
+		background: rgb(0 0 0 / 0.75);
 		backdrop-filter: blur($filter-blur-default);
 	}
-}
 
-.sliderBubble {
-	background: rgb(0 0 0 / 0.75);
-	backdrop-filter: blur($filter-blur-default);
-}
-
-.osdTextContainer{
-	font-family: monospace;
+	.osdTextContainer{
+		font-family: monospace;
+	}
 }

--- a/src/pages/_titlePage.scss
+++ b/src/pages/_titlePage.scss
@@ -1,431 +1,434 @@
 /** @format */
 
 @use "../abstract/variables" as *;
+@use "../abstract/config" as config;
 
-#itemDetailPage {
-	--card-width: 14vw;
-	display: flex;
-	flex-direction: column;
-	flex-wrap: nowrap;
-	justify-content: flex-start;
-	align-items: flex-start;
-	overflow-y: auto;
-	padding: 3.2em !important;
-	.mediaInfoItem.mediaInfoOfficialRating {
-		border-radius: 5px;
-		background: rgb(255 255 255 / 0.8);
-		color: #000;
-		border: none;
-		font-weight: 600;
-		white-space: nowrap;
-	}
-
-	.detailRibbon {
-		height: 60vh;
-		margin-top: 0;
-		background: transparent;
-		font-size: 2.2vh;
-		position: static !important;
-		display: flex;
-		flex-direction: column;
-		align-items: stretch;
-		.itemMiscInfo {
-			margin-bottom: 0 !important;
-		}
-	}
-	.infoWrapper {
-		display: grid;
-		grid-template-areas:
-			"img text"
-			"img info"
-			"img info";
-		grid-template-columns: var(--card-width) 1fr;
-		column-gap: 2em;
-		row-gap: 1em;
-		grid-template-rows: 1fr auto auto;
-		flex: unset !important;
-		align-items: end;
-		.nameContainer {
-			grid-area: text;
-		}
-		.itemMiscInfo {
-			grid-area: info;
-		}
-		.itemName {
-			font-size: 3em;
-			color: white;
-			&.subtitle {
-				font-size: 1.4em;
-				margin: 0 !important;
-				padding: 0 !important;
-			}
-		}
-	}
-	.detailImageContainer {
-		grid-area: img;
-		padding: 0 !important;
-		width: var(--card-width);
-		.card {
-			width: 100%;
-			position: static !important;
-			border-radius: $rounding-default;
-			.cardBox {
-				margin: 0 !important;
-			}
-		}
-	}
-	.detailPageWrapperContainer {
-		width: 100%;
-		display: flex;
-		flex-direction: column;
-		& > * {
-			padding: 0 !important;
-			background: transparent;
-		}
-	}
-	.detailPageContent {
-		padding-left: 0 !important;
-	}
-	.mainDetailButtons
-		.emby-button:not([data-action="resume"], [data-action="play"]) {
-		background: transparent !important;
-	}
-	.detailLogo {
-		display: none;
-	}
-	.emby-button {
-		background: transparent !important;
-		border-radius: 10vh;
-		flex-flow: row;
-		justify-content: center;
-		align-items: center;
-		text-decoration: none;
-		margin-right: 0.5em !important;
-		&[is="emby-linkbutton"] {
-			color: unset;
-		}
-		&:not([is="emby-linkbutton"]) {
-			&:hover {
-				background: rgb(255 255 255 / 0.1) !important;
-				color: white;
-			}
-
-			&::after {
-				display: none;
-			}
-		}
-
-		&[title="Play"],
-		&[title="Resume"] {
-			background: white !important;
-			color: black;
-			padding: 0.4em 1em !important;
-			gap: 0.6em;
-			margin-right: 0.5em;
-			width: var(--card-width);
-			&::after {
-				content: attr(title);
-				display: block;
-				opacity: 1;
-				background: transparent;
-				position: static;
-				font-weight: 500;
-				height: fit-content;
-				font-size: 1.5em;
-				width: fit-content;
-			}
-			&:hover {
-				background: hsl(0, 0%, 80%) !important;
-				color: black;
-			}
-		}
-	}
-	.childrenItemsContainer.itemsContainer.vertical-list {
-		padding: 0;
-		.listItem {
-			.paper-icon-button-light {
-				&[data-action="menu"]::after {
-					content: "";
-					margin-left: 100%;
-				}
-				&.listItemImageButton {
-					aspect-ratio: 1;
-					border-radius: 100%;
-					background: $gradient-default;
-					color: white;
-					opacity: 0;
-					box-shadow: 0 0 0 10em rgb(255 255 255 / 0.1);
-					transition: opacity $transition-time-default;
-				}
-			}
-			&[data-type="Episode"] {
-				padding: 0;
-				margin: 0 !important;
-				background: transparent !important;
-				& .listItem-content {
-					display: grid;
-					grid-template-columns: 25% 1fr 15%;
-					align-content: center;
-					align-items: center;
-					&:hover {
-						.listItemImageButton {
-							opacity: 1;
-						}
-					}
-				}
-			}
-
-			// 	&-content {
-			// 		flex-direction: column;
-			// 	}
-			&Image-large {
-				justify-self: center;
-				margin: 2em !important;
-				// margin: 0 !important;
-				border-radius: $rounding-default;
-				overflow: hidden;
-				height: 12em;
-			}
-			// 	&-overview {
-			// 		text-overflow: ellipsis;
-			// 		white-space: nowrap;
-			// 		text-align: start;
-			// 		width: 100%;
-			// 		overflow: hidden;
-			// 	}
-
-			// 	&Body {
-			// 		width: 95%;
-			// 	}
-		}
-	}
-	.listItem {
-		flex-flow: column !important;
-	}
-	.listItem[data-mediatype="Audio"] {
-		flex-flow: row !important;
-		grid-column: auto / span 3;
-	}
-	.detailsGroupItem {
-		max-width: 100% !important;
-	}
-	.detailSection {
-		display: grid;
-		grid-template-areas:
-			"content selector"
-			"detailGroup detailGroup"
-			"recording recording";
-		grid-template-columns: 1fr 40%;
-		gap: 2em;
-		.itemDetailsGroup {
-			grid-area: detailGroup;
-		}
-		.recordingFields {
-			grid-area: recording;
-		}
-		.detailSectionContent {
-			grid-area: content;
-		}
-		.trackSelections {
-			grid-area: selector;
-		}
-	}
-	.tagline {
-		border-left: 0.25em solid rgb(255 255 255);
-		padding: 0 0.5em;
-		color: white;
-	}
-	// Episode Page
-	&:has(.parentName a[data-type="Series"]):not(:has(.listItem)) {
-		--card-width: 24vw;
-		.detailPagePrimaryContainer {
-			margin-top: 8.5vh;
-		}
-		.detailRibbon {
-			height: 43vh;
-		}
-	}
-}
-
-// mobile
-.layout-mobile #itemDetailPage {
-	--card-width: 100%;
-	.itemBackdrop {
-		position: absolute !important;
-		width: 100vw;
-		height: 90vh !important;
-		top: 0;
-		left: 0;
-		filter: brightness(65%);
-		margin-top: 0 !important;
-		mask-image: linear-gradient(to bottom, black, transparent);
-		-webkit-mask-image: linear-gradient(to bottom, black, transparent);
-	}
-	&:has(.parentName a[data-type="Series"]):not(:has(.listItem)) {
-		.detailRibbon {
-			height: 60vh;
-			--card-width: 100%;
-			.detailImageContainer .card{
-				max-width: 80vw !important;
-				min-width: 80vw !important;
-			}
-		}
-		.itemBackdrop{
-			height: 55vh !important;
-		}
-	}
-	.detail {
-		&Ribbon {
-			height: 90vh;
-			display: flex;
-			flex-direction: column;
-			align-items: flex-start;
-			justify-content: flex-end;
-			margin-top: 0 !important;
-		}
-		&ImageContainer {
-			position: static;
-			overflow: hidden;
-			padding: 0 !important;
-			.card {
-				top: 0;
-				max-width: 60vw !important;
-				min-width: 60vw;
-				margin: auto !important;
-				position: static !important;
-				transform: none;
-				filter: none !important;
-				&Box {
-					margin: 0 !important;
-					box-shadow: none;
-				}
-			}
-		}
-		&Section {
-			display: flex;
-			flex-direction: column;
-			margin-top: 2em;
-			font-size: 1.3em;
-		}
-		&PageContent {
-			padding-right: 0;
-		}
-	}
-	.itemMiscInfo {
-		justify-content: flex-start;
-	}
-	.infoText {
-		text-align: start;
-		width: fit-content !important;
-	}
-	.infoWrapper {
+@if config.$pages-titlePage {
+	#itemDetailPage {
+		--card-width: 14vw;
 		display: flex;
 		flex-direction: column;
 		flex-wrap: nowrap;
+		justify-content: flex-start;
 		align-items: flex-start;
-		justify-content: flex-end;
-		padding: 0 !important;
-	}
-	.mainDetailButtons {
-		flex-direction: row;
-		flex-wrap: wrap;
-		row-gap: 0.5em !important;
-		column-gap: 0.5em !important;
-		// width: 100%;
-		// flex-wrap: nowrap;
-		// justify-content: flex-start;
-		// overflow: auto;
-		.emby-button[title="Play"],
-		.emby-button[title="Resume"] {
-			width: 100%;
+		overflow-y: auto;
+		padding: 3.2em !important;
+		.mediaInfoItem.mediaInfoOfficialRating {
+			border-radius: 5px;
+			background: rgb(255 255 255 / 0.8);
+			color: #000;
+			border: none;
+			font-weight: 600;
+			white-space: nowrap;
 		}
-	}
-	.childrenItemsContainer.itemsContainer.vertical-list {
-		grid-template-columns: 1fr;
-		.listItemImage {
-			margin: 0 !important;
-			padding: 0 !important;
-			width: 100%;
-			flex-shrink: 0;
-			flex-grow: 1;
-			flex-basis: 20vh;
-		}
-		.listItem-bottomoverview {
-			font-size: 88%;
-			margin-bottom: 1em;
-			margin-top: 0.2em;
-			padding: 0 1em 1em 1em;
-		}
-	}
-	.emby-button {
-		margin: 0 !important;
-	}
-}
 
-@media (orientation: landscape) {
+		.detailRibbon {
+			height: 60vh;
+			margin-top: 0;
+			background: transparent;
+			font-size: 2.2vh;
+			position: static !important;
+			display: flex;
+			flex-direction: column;
+			align-items: stretch;
+			.itemMiscInfo {
+				margin-bottom: 0 !important;
+			}
+		}
+		.infoWrapper {
+			display: grid;
+			grid-template-areas:
+				"img text"
+				"img info"
+				"img info";
+			grid-template-columns: var(--card-width) 1fr;
+			column-gap: 2em;
+			row-gap: 1em;
+			grid-template-rows: 1fr auto auto;
+			flex: unset !important;
+			align-items: end;
+			.nameContainer {
+				grid-area: text;
+			}
+			.itemMiscInfo {
+				grid-area: info;
+			}
+			.itemName {
+				font-size: 3em;
+				color: white;
+				&.subtitle {
+					font-size: 1.4em;
+					margin: 0 !important;
+					padding: 0 !important;
+				}
+			}
+		}
+		.detailImageContainer {
+			grid-area: img;
+			padding: 0 !important;
+			width: var(--card-width);
+			.card {
+				width: 100%;
+				position: static !important;
+				border-radius: $rounding-default;
+				.cardBox {
+					margin: 0 !important;
+				}
+			}
+		}
+		.detailPageWrapperContainer {
+			width: 100%;
+			display: flex;
+			flex-direction: column;
+			& > * {
+				padding: 0 !important;
+				background: transparent;
+			}
+		}
+		.detailPageContent {
+			padding-left: 0 !important;
+		}
+		.mainDetailButtons
+			.emby-button:not([data-action="resume"], [data-action="play"]) {
+			background: transparent !important;
+		}
+		.detailLogo {
+			display: none;
+		}
+		.emby-button {
+			background: transparent !important;
+			border-radius: 10vh;
+			flex-flow: row;
+			justify-content: center;
+			align-items: center;
+			text-decoration: none;
+			margin-right: 0.5em !important;
+			&[is="emby-linkbutton"] {
+				color: unset;
+			}
+			&:not([is="emby-linkbutton"]) {
+				&:hover {
+					background: rgb(255 255 255 / 0.1) !important;
+					color: white;
+				}
+
+				&::after {
+					display: none;
+				}
+			}
+
+			&[title="Play"],
+			&[title="Resume"] {
+				background: white !important;
+				color: black;
+				padding: 0.4em 1em !important;
+				gap: 0.6em;
+				margin-right: 0.5em;
+				width: var(--card-width);
+				&::after {
+					content: attr(title);
+					display: block;
+					opacity: 1;
+					background: transparent;
+					position: static;
+					font-weight: 500;
+					height: fit-content;
+					font-size: 1.5em;
+					width: fit-content;
+				}
+				&:hover {
+					background: hsl(0, 0%, 80%) !important;
+					color: black;
+				}
+			}
+		}
+		.childrenItemsContainer.itemsContainer.vertical-list {
+			padding: 0;
+			.listItem {
+				.paper-icon-button-light {
+					&[data-action="menu"]::after {
+						content: "";
+						margin-left: 100%;
+					}
+					&.listItemImageButton {
+						aspect-ratio: 1;
+						border-radius: 100%;
+						background: $gradient-default;
+						color: white;
+						opacity: 0;
+						box-shadow: 0 0 0 10em rgb(255 255 255 / 0.1);
+						transition: opacity $transition-time-default;
+					}
+				}
+				&[data-type="Episode"] {
+					padding: 0;
+					margin: 0 !important;
+					background: transparent !important;
+					& .listItem-content {
+						display: grid;
+						grid-template-columns: 25% 1fr 15%;
+						align-content: center;
+						align-items: center;
+						&:hover {
+							.listItemImageButton {
+								opacity: 1;
+							}
+						}
+					}
+				}
+
+				// 	&-content {
+				// 		flex-direction: column;
+				// 	}
+				&Image-large {
+					justify-self: center;
+					margin: 2em !important;
+					// margin: 0 !important;
+					border-radius: $rounding-default;
+					overflow: hidden;
+					height: 12em;
+				}
+				// 	&-overview {
+				// 		text-overflow: ellipsis;
+				// 		white-space: nowrap;
+				// 		text-align: start;
+				// 		width: 100%;
+				// 		overflow: hidden;
+				// 	}
+
+				// 	&Body {
+				// 		width: 95%;
+				// 	}
+			}
+		}
+		.listItem {
+			flex-flow: column !important;
+		}
+		.listItem[data-mediatype="Audio"] {
+			flex-flow: row !important;
+			grid-column: auto / span 3;
+		}
+		.detailsGroupItem {
+			max-width: 100% !important;
+		}
+		.detailSection {
+			display: grid;
+			grid-template-areas:
+				"content selector"
+				"detailGroup detailGroup"
+				"recording recording";
+			grid-template-columns: 1fr 40%;
+			gap: 2em;
+			.itemDetailsGroup {
+				grid-area: detailGroup;
+			}
+			.recordingFields {
+				grid-area: recording;
+			}
+			.detailSectionContent {
+				grid-area: content;
+			}
+			.trackSelections {
+				grid-area: selector;
+			}
+		}
+		.tagline {
+			border-left: 0.25em solid rgb(255 255 255);
+			padding: 0 0.5em;
+			color: white;
+		}
+		// Episode Page
+		&:has(.parentName a[data-type="Series"]):not(:has(.listItem)) {
+			--card-width: 24vw;
+			.detailPagePrimaryContainer {
+				margin-top: 8.5vh;
+			}
+			.detailRibbon {
+				height: 43vh;
+			}
+		}
+	}
+
+	// mobile
 	.layout-mobile #itemDetailPage {
+		--card-width: 100%;
+		.itemBackdrop {
+			position: absolute !important;
+			width: 100vw;
+			height: 90vh !important;
+			top: 0;
+			left: 0;
+			filter: brightness(65%);
+			margin-top: 0 !important;
+			mask-image: linear-gradient(to bottom, black, transparent);
+			-webkit-mask-image: linear-gradient(to bottom, black, transparent);
+		}
+		&:has(.parentName a[data-type="Series"]):not(:has(.listItem)) {
+			.detailRibbon {
+				height: 60vh;
+				--card-width: 100%;
+				.detailImageContainer .card{
+					max-width: 80vw !important;
+					min-width: 80vw !important;
+				}
+			}
+			.itemBackdrop{
+				height: 55vh !important;
+			}
+		}
 		.detail {
 			&Ribbon {
-				flex-direction: row;
-				margin-top: 10vh !important;
-				justify-content: center;
-				align-items: center;
-				.info {
-					&Wrapper {
-						display: grid;
-						grid-template-areas:
-							"card name"
-							"card info";
-						flex-direction: row;
-						flex-basis: 50vw;
-						align-items: center;
-						.detailImageContainer {
-							grid-area: card;
-						}
-						.nameContainer {
-							grid-area: name;
-							align-self: self-end;
-							justify-self: flex-end;
-							width: calc(100% - 1.2em);
-							text-overflow: ellipsis;
-						}
-						.itemMiscInfo-primary {
-							grid-area: info;
-							align-self: self-start;
-							justify-self: flex-end;
-							width: calc(100% - 1.2em);
-							text-overflow: ellipsis;
-						}
-					}
-					&Text {
-						text-align: start;
-						width: fit-content !important;
-						font-size: 3.2em;
-						max-width: fit-content;
-						-webkit-line-clamp: 2;
-						-webkit-box-orient: vertical;
-						display: -webkit-box;
-						overflow: hidden;
-					}
-				}
+				height: 90vh;
+				display: flex;
+				flex-direction: column;
+				align-items: flex-start;
+				justify-content: flex-end;
+				margin-top: 0 !important;
 			}
 			&ImageContainer {
+				position: static;
+				overflow: hidden;
+				padding: 0 !important;
 				.card {
-					min-width: 20vw;
-					max-width: 40vw !important;
-					width: 100%;
+					top: 0;
+					max-width: 60vw !important;
+					min-width: 60vw;
+					margin: auto !important;
+					position: static !important;
+					transform: none;
+					filter: none !important;
+					&Box {
+						margin: 0 !important;
+						box-shadow: none;
+					}
 				}
 			}
+			&Section {
+				display: flex;
+				flex-direction: column;
+				margin-top: 2em;
+				font-size: 1.3em;
+			}
+			&PageContent {
+				padding-right: 0;
+			}
+		}
+		.itemMiscInfo {
+			justify-content: flex-start;
+		}
+		.infoText {
+			text-align: start;
+			width: fit-content !important;
+		}
+		.infoWrapper {
+			display: flex;
+			flex-direction: column;
+			flex-wrap: nowrap;
+			align-items: flex-start;
+			justify-content: flex-end;
+			padding: 0 !important;
 		}
 		.mainDetailButtons {
-			width: fit-content;
-			margin: 0 !important;
-			padding: 0 !important;
-			flex-basis: 50vw;
-			font-size: 1.5em;
+			flex-direction: row;
+			flex-wrap: wrap;
+			row-gap: 0.5em !important;
+			column-gap: 0.5em !important;
+			// width: 100%;
+			// flex-wrap: nowrap;
+			// justify-content: flex-start;
+			// overflow: auto;
+			.emby-button[title="Play"],
+			.emby-button[title="Resume"] {
+				width: 100%;
+			}
 		}
-		.parentName a {
-			text-align: start;
+		.childrenItemsContainer.itemsContainer.vertical-list {
+			grid-template-columns: 1fr;
+			.listItemImage {
+				margin: 0 !important;
+				padding: 0 !important;
+				width: 100%;
+				flex-shrink: 0;
+				flex-grow: 1;
+				flex-basis: 20vh;
+			}
+			.listItem-bottomoverview {
+				font-size: 88%;
+				margin-bottom: 1em;
+				margin-top: 0.2em;
+				padding: 0 1em 1em 1em;
+			}
+		}
+		.emby-button {
+			margin: 0 !important;
+		}
+	}
+
+	@media (orientation: landscape) {
+		.layout-mobile #itemDetailPage {
+			.detail {
+				&Ribbon {
+					flex-direction: row;
+					margin-top: 10vh !important;
+					justify-content: center;
+					align-items: center;
+					.info {
+						&Wrapper {
+							display: grid;
+							grid-template-areas:
+								"card name"
+								"card info";
+							flex-direction: row;
+							flex-basis: 50vw;
+							align-items: center;
+							.detailImageContainer {
+								grid-area: card;
+							}
+							.nameContainer {
+								grid-area: name;
+								align-self: self-end;
+								justify-self: flex-end;
+								width: calc(100% - 1.2em);
+								text-overflow: ellipsis;
+							}
+							.itemMiscInfo-primary {
+								grid-area: info;
+								align-self: self-start;
+								justify-self: flex-end;
+								width: calc(100% - 1.2em);
+								text-overflow: ellipsis;
+							}
+						}
+						&Text {
+							text-align: start;
+							width: fit-content !important;
+							font-size: 3.2em;
+							max-width: fit-content;
+							-webkit-line-clamp: 2;
+							-webkit-box-orient: vertical;
+							display: -webkit-box;
+							overflow: hidden;
+						}
+					}
+				}
+				&ImageContainer {
+					.card {
+						min-width: 20vw;
+						max-width: 40vw !important;
+						width: 100%;
+					}
+				}
+			}
+			.mainDetailButtons {
+				width: fit-content;
+				margin: 0 !important;
+				padding: 0 !important;
+				flex-basis: 50vw;
+				font-size: 1.5em;
+			}
+			.parentName a {
+				text-align: start;
+			}
 		}
 	}
 }


### PR DESCRIPTION
I have introduced a set of configuration variables that can be used to selectively include or exclude core parts of the theme to allow for a person to more easily customize the theme to their liking fr om the sources. This is done by setting true or false to include or exclude parts respectively in the _config.sscs file in the abstract folder. The variables defined in the _config.scss file turn off whole classes of changes from individual components to the full page reworks. By default all options are set to maintain the current theme look and feel.

I have also corrected a bug with the Skip Intro button on the latest version of Jellyfin. This is due to a change in the class name for the button from .skipIntro to .skip-button.