### PR TITLE
Fix the stretched and mangled "skip" button

### DIFF
--- a/src/components/_button.scss
+++ b/src/components/_button.scss
@@ -3,7 +3,6 @@
 @use "../abstract/variables" as ab;
 
 .emby-button {
-	position: relative;
 	&[is="emby-button"]:not(.emby-tab-button),
 	&.raised[is="emby-linkbutton"]:not(.emby-tab-button) {
 		background: ab.$background-dark;


### PR DESCRIPTION
What:
Removed position: relative from .emby-button 

Why:
Fix the stretched and mangled "skip" button bug caused by jellyfin10.10.4