### PR TITLE
fix title and logo offset

### DIFF
--- a/src/logo.scss
+++ b/src/logo.scss
@@ -21,7 +21,7 @@ body #itemDetailPage {
 	}
 	.detailLogo {
 		left: 18.8vw;
-		top: 17.5vh;
+		top: 14vh;
 		height: 30vh;
 		background-position: left bottom !important;
 	}

--- a/src/pages/_titlePage.scss
+++ b/src/pages/_titlePage.scss
@@ -388,6 +388,7 @@
 							justify-self: flex-end;
 							width: calc(100% - 1.2em);
 							text-overflow: ellipsis;
+							margin-bottom: 100px;
 						}
 						.itemMiscInfo-primary {
 							grid-area: info;
@@ -429,3 +430,4 @@
 		}
 	}
 }
+


### PR DESCRIPTION
Before
<img width="1875" height="900" alt="Screenshot 2025-08-15 162046" src="https://github.com/user-attachments/assets/164258f0-4649-4eaf-bb4b-43c764c3edf8" />

After
<img width="1876" height="894" alt="Screenshot 2025-08-15 162613" src="https://github.com/user-attachments/assets/6ce15fd6-fb24-41d7-a6f5-a6dca8604db4" />

